### PR TITLE
Added Commit Hash to the assemble info

### DIFF
--- a/build-webapi-netfx.cake
+++ b/build-webapi-netfx.cake
@@ -59,7 +59,8 @@ Task("Version")
                 new AssemblyInfoSettings
                 {
                     Version = version,
-                    InformationalVersion = packageVersion
+                    InformationalVersion = packageVersion,
+                    Description = BuildSystem.AppVeyor.Environment.Repository.Commit.Id
                 });
         }
     });


### PR DESCRIPTION
This is used in our new `_git_hash` endpoint in RimDev.WebApi.