### PR TITLE
Set versions for items to reduce build noise

### DIFF
--- a/build-webapi-netfx.cake
+++ b/build-webapi-netfx.cake
@@ -1,6 +1,5 @@
-
-#addin "Cake.FileHelpers"
-#tool "nuget:?package=xunit.runner.console"
+#addin nuget:?package=Cake.FileHelpers&version=3.1.0
+#tool nuget:?package=xunit.runner.console&version=2.4.1
 
 var target = Argument("target", "Default");
 var version = FileReadText("./version.txt").Trim();


### PR DESCRIPTION
Cleanup this part of the noise:

```
The 'tool' directive is attempting to install the 'xunit.runner.console' package 
without specifying a package version number.  
More information on this can be found at https://cakebuild.net/docs/tutorials/pinning-cake-version 
It's not recommended, but you can explicitly override this warning 
by configuring the Skip Package Version Check setting to true 
(i.e. command line parameter "--settings_skippackageversioncheck=true", 
environment variable "CAKE_SETTINGS_SKIPPACKAGEVERSIONCHECK=true", 
read more about configuration at https://cakebuild.net/docs/fundamentals/configuration)
The 'addin' directive is attempting to install the 'Cake.FileHelpers' package 
without specifying a package version number.  
More information on this can be found at https://cakebuild.net/docs/tutorials/pinning-cake-version 
It's not recommended, but you can explicitly override this warning 
by configuring the Skip Package Version Check setting to true 
(i.e. command line parameter "--settings_skippackageversioncheck=true", 
environment variable "CAKE_SETTINGS_SKIPPACKAGEVERSIONCHECK=true", 
read more about configuration at https://cakebuild.net/docs/fundamentals/configuration)
```