### PR TITLE
Include symbols in DotNetCorePack() call

### DIFF
--- a/build-netcoreapp.cake
+++ b/build-netcoreapp.cake
@@ -116,7 +116,7 @@ Task("Package")
             hostArtifactsDir + File("githash.txt"),
             BuildSystem.AppVeyor.Environment.Repository.Commit.Id);
 
-        // work around for datetime offset problem 
+        // work around for datetime offset problem
         var now = DateTime.UtcNow;
         foreach(var file in GetFiles($"{hostArtifactsDir}/**/*.*"))
         {
@@ -140,7 +140,8 @@ Task("Package")
                 Configuration = configuration,
                 MSBuildSettings = new DotNetCoreMSBuildSettings().SetVersion(packageVersion),
                 NoBuild = true,
-                OutputDirectory = artifactsDir
+                OutputDirectory = artifactsDir,
+                IncludeSymbols = true
             });
         }
     });

--- a/build-webapi-netfx.cake
+++ b/build-webapi-netfx.cake
@@ -134,7 +134,8 @@ Task("Package")
                     Configuration = configuration,
                     MSBuildSettings = new DotNetCoreMSBuildSettings().SetVersion(packageVersion),
                     NoBuild = true,
-                    OutputDirectory = artifactsDir
+                    OutputDirectory = artifactsDir,
+                    IncludeSymbols = true
                 });
             }
             else


### PR DESCRIPTION
This will probably fix https://github.com/ritterim/contracting-api/issues/1253 and https://github.com/ritterim/rimdev-aspnetcore/issues/105 -- but I need to verify those.

Ref:

https://cakebuild.net/api/Cake.Common.Tools.DotNetCore.Pack/DotNetCorePackSettings/

Note that under the old build using NuGetPack(), this setting was `Symbols = true`.  