### PR TITLE
Rewrite to only support TLS 1.3, with 1.2 fallback

### DIFF
--- a/bootstrap-cake.ps1
+++ b/bootstrap-cake.ps1
@@ -51,17 +51,21 @@ Param(
 )
 
 # Attempt to set highest encryption available for SecurityProtocol.
+# See also: 
+# - https://github.com/cake-build/resources/blob/master/dotnet-framework/build.ps1
+# - https://chocolatey.org/install.ps1
+# - https://www.medo64.com/2020/05/using-tls-1-3-from-net-4-0-application/
 # PowerShell will not set this by default (until maybe .NET 4.6.x). This
 # will typically produce a message for PowerShell v2 (just an info
 # message though)
 try {
-    # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
+    # Set TLS 1.3 (12288) or TLS 1.2 (3072)
     # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
     # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
     # installed (.NET 4.5 is an in-place upgrade).
-    [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+    [System.Net.ServicePointManager]::SecurityProtocol = 12288 -bor 3072
   } catch {
-    Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
+    Write-Output 'Unable to set PowerShell to use TLS 1.3 or TLS 1.2.'
   }
 
 [Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null


### PR DESCRIPTION
Part of the work to make the bootstrap-cake.ps1 file work under macOS as well as Windows.

It's possible that we don't need to do this at all if we only want to support TLS 1.3 and newer.  The [chocolatey.org install.ps1](https://chocolatey.org/install.ps1) uses:

`[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072`

We definitely should not be supporting TLS 1.1 and older.