### PR TITLE
IsWindows / IsMacOS / IsLinux are only on PS 6.0+

### DIFF
--- a/bootstrap-cake.ps1
+++ b/bootstrap-cake.ps1
@@ -178,7 +178,7 @@ if ($IsWindows) {
         }
     }
 } else {
-    Throw "Running on unknown operating system."
+    Throw "Running on unknown operating system.  One possible fix is to upgrade to Powershell 6.0+."
 }
 
 # Try download NuGet.exe if not exists


### PR DESCRIPTION
Add note that you need Powershell 6.0+ in order to use this script.
The IsWindows / etc. variables are not available in PS 5.1.

Follow-up for https://github.com/ritterim/build-scripts/pull/32