### PR TITLE
Build script errors due to newer version of Cake

### DIFF
--- a/bootstrap-cake.ps1
+++ b/bootstrap-cake.ps1
@@ -292,10 +292,12 @@ if ($DryRun) { $cakeArguments += "-dryrun" }
 $cakeArguments += $ScriptArgs
 
 # Start Cake
-Write-Host "Running build script..."
+Write-Host "Running build script using Cake..."
 if ($IsLinux -or $IsMacOS) {
+    Invoke-Expression "&`"$MONO_EXECUTABLE`" `"$CAKE_EXE`" --version"
     Invoke-Expression "&`"$MONO_EXECUTABLE`" `"$CAKE_EXE`" $cakeArguments"
 } else {
+    Invoke-Expression "&`"$CAKE_EXE`" --version"
     Invoke-Expression "&`"$CAKE_EXE`" $cakeArguments"
 }
 

--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,9 @@ $scripts = @(".\build-webapi-netfx.cake")
 # Verify $scripts do not contain compilation errors
 foreach ($script in $scripts) {
   Write-Output ""
+  Write-Output "----- TESTING: $script -----"
   .\bootstrap-cake.ps1 -Script $script -Verbose --verbosity=Normal --Target=Clean --exclusive
+  Write-Output "----- FINISH: $script -----"
 
   if ($LastExitCode -ne 0) {
       $failed = $true

--- a/build.ps1
+++ b/build.ps1
@@ -5,7 +5,8 @@ $scripts = @(".\build-webapi-netfx.cake")
 
 # Verify $scripts do not contain compilation errors
 foreach ($script in $scripts) {
-  .\bootstrap-cake.ps1 -Script $script -Target Clean --exclusive
+  Write-Output ""
+  .\bootstrap-cake.ps1 -Script $script -Verbose --verbosity=Normal --Target=Clean --exclusive
 
   if ($LastExitCode -ne 0) {
       $failed = $true

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,11 @@
 
 $failed = $false
 
-$scripts = @(".\build-webapi-netfx.cake")
+$scripts = @(
+  ".\build-webapi-netfx.cake",
+  ".\build-netcoreapp.cake",
+  ".\build-net5.cake"
+  )
 
 # Verify $scripts do not contain compilation errors
 foreach ($script in $scripts) {


### PR DESCRIPTION
We seem to be pulling down a newer version of cake, which did not like the following

`-Target Clean` 

versus the following which works 

`--Target=Clean`

Also took the opportunity to add some debug output and the other two build.cake templates to the sanity test.