### PR TITLE
Update README around .NET 5 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Ritter Insurance Marketing project specific build scripts.
 
 - `build-webapi-netfx.cake` ASP.NET WebApi2 with full .NET framework
-- `build-netcoreapp.cake` ASP.NET Core
+- `build-netcoreapp.cake` ASP.NET Core (somewhat obsolete)
+- `build-net5.cake` .NET 5 projects, including creating multiple Nuget packages
 
 ## Usage
 
@@ -24,7 +25,7 @@ New-Item -ItemType directory -Path "build" -Force | Out-Null
 
 try {
   Invoke-WebRequest https://raw.githubusercontent.com/ritterim/build-scripts/master/bootstrap-cake.ps1 -OutFile build\bootstrap-cake.ps1
-  Invoke-WebRequest https://raw.githubusercontent.com/ritterim/build-scripts/master/build-[webapi-netfx OR netcoreapp].cake -OutFile build.cake
+  Invoke-WebRequest https://raw.githubusercontent.com/ritterim/build-scripts/master/build-[webapi-netfx OR net5].cake -OutFile build.cake
 }
 catch {
   Write-Output $_.Exception.Message
@@ -37,11 +38,15 @@ Exit $LastExitCode
 
 ### Create version.txt
 
-Example:
+The version number for the NuGet package is sourced from a version.txt file in the root directory of the solution.
+
+Example version.txt:
 
 ```
 1.0.0
 ```
+
+Note that even if you provide the patch value for _major.minor.patch_, many of the Cake recipes ignore that value and replace the patch value with the AppVeyor build number.
 
 ### Use AssemblyInfo.Generated.cs *(`build-webapi-netfx.cake` only)*
 


### PR DESCRIPTION
The build-net5.cake file is supplanting the old build-netcoreapp.cake file.