### PR TITLE
Update build-net5.cake to handle NPM+C# projects

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -3,6 +3,7 @@
 #addin nuget:?package=Cake.Docker&version=0.11.1
 #tool nuget:?package=xunit.runner.console&version=2.4.1
 
+Information("build-net5.cake -- Jul-26-2021");
 var target = Argument("target", "Default");
 var versionFromFile = FileReadText("./version.txt")
                     .Trim()


### PR DESCRIPTION
Some of our solutions use the pattern of:

- Vue.js and NPM on the UI layer
- C# (.NET Core / .NET 5) on the backend
- Optionally publishing 1+ NuGet packages

We also have to handle two different release strategies:

- Release on merge to master/main branch.
- Release when a `release/*` branch is cut.

This Cake file is currently only used by some of our .NET Core / .NET 5 solutions.