### PR TITLE
Simplify the logic for Release vs Debug configs

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -34,16 +34,12 @@ else if ((useMasterReleaseStrategy && AppVeyor.Environment.Repository.Branch != 
 Information($"packageVersion={packageVersion}");
 
 var configuration = "Release";
-if (!useMasterReleaseStrategy
-    && !AppVeyor.Environment.PullRequest.IsPullRequest
-    && AppVeyor.Environment.Repository.Branch == "master")
+if (AppVeyor.Environment.PullRequest.IsPullRequest
+    && (useMasterReleaseStrategy && AppVeyor.Environment.Repository.Branch != "master")
+    && (!useMasterReleaseStrategy && !AppVeyor.Environment.Repository.Branch.StartsWith("release/"))
+    )
 {
-    configuration = "Development";
-}
-else if (!AppVeyor.Environment.PullRequest.IsPullRequest
-    && AppVeyor.Environment.Repository.Branch == "development")
-{
-    configuration = "QA";
+    configuration = "Debug";
 }
 Information($"configuration={configuration}");
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+pwsh -ExecutionPolicy RemoteSigned -File ./build.ps1
+


### PR DESCRIPTION
The old logic (which included Development config and
the QA config) is outdated.  Under .NET Core, we are only
using Debug/Release configurations.