### PR TITLE
Always build Release configuration

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -34,13 +34,6 @@ else if ((useMasterReleaseStrategy && AppVeyor.Environment.Repository.Branch != 
 Information($"packageVersion={packageVersion}");
 
 var configuration = "Release";
-if (AppVeyor.Environment.PullRequest.IsPullRequest
-    && (useMasterReleaseStrategy && AppVeyor.Environment.Repository.Branch != "master")
-    && (!useMasterReleaseStrategy && !AppVeyor.Environment.Repository.Branch.StartsWith("release/"))
-    )
-{
-    configuration = "Debug";
-}
 Information($"configuration={configuration}");
 
 var artifactsDir = Directory("./artifacts");


### PR DESCRIPTION
The build.cake file is mostly used in AppVeyor and there's
no need to build a Debug config via this method.