### PR TITLE
Use NuGet "snupkg" format for symbols package

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -328,7 +328,12 @@ Task("Package")
                     MSBuildSettings = new DotNetCoreMSBuildSettings().SetVersion(packageVersion),
                     NoBuild = true,
                     OutputDirectory = artifactsDir,
-                    IncludeSymbols = true
+                    IncludeSymbols = true,
+
+                    //TODO: Remove ArgumentCustomization, add SymbolPackageFormat once Cake 1.2 is released
+                    // https://github.com/cake-build/cake/pull/3331
+                    ArgumentCustomization = x => x.Append("-p:SymbolPackageFormat=snupkg")
+                    //SymbolPackageFormat = "snupkg",
                 });
             }
         }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

Symbol package publishing is only supported by the NuGet V3 API.

NuGet.org supports its own symbols server repository and only accepts the
new symbol package format - .snupkg.

https://github.com/cake-build/cake/issues/2362
https://github.com/cake-build/cake/pull/3331