### PR TITLE
Use package id to find client projects for publishing

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -3,7 +3,7 @@
 #addin nuget:?package=Cake.Docker&version=0.11.1
 #tool nuget:?package=xunit.runner.console&version=2.4.1
 
-Information("build-net5.cake -- Dec-7-2021");
+Information("build-net5.cake -- Dec-8-2021");
 var target = Argument("target", "Default");
 
 // RELEASE STRATEGY: old vs new git flow (master branch vs trunk-based release strategy)
@@ -340,18 +340,18 @@ Task("Package")
         foreach (var clientProject in clientProjects)
         {
             var clientProjectPath = clientProject.ToString();
-            Information($"\nclientProjectPath={clientProjectPath}");
-
             // XmlPeek - https://stackoverflow.com/a/34886946
             var packageId = XmlPeek(
                 clientProjectPath,
                 "/Project/PropertyGroup/PackageId/text()",
                 new XmlPeekSettings { SuppressWarning = true }
                 );
-            Information($"packageId={packageId}");
 
             if (!string.IsNullOrWhiteSpace(packageId))
             {
+                Information($"\nclientProjectPath={clientProjectPath}");
+                Information($"packageId={packageId}");
+
                 DotNetCorePack(clientProjectPath, new DotNetCorePackSettings
                 {
                     Configuration = configuration,

--- a/build-webapi-netfx.cake
+++ b/build-webapi-netfx.cake
@@ -140,6 +140,7 @@ Task("Package")
 
             foreach (var clientProject in clientProjects)
             {
+                var clientProjectPath = clientProject.ToString();
                 // XmlPeek - https://stackoverflow.com/a/34886946
                 var packageId = XmlPeek(
                     clientProjectPath,
@@ -149,7 +150,6 @@ Task("Package")
 
                 if (!string.IsNullOrWhiteSpace(packageId))
                 {
-                    var clientProjectPath = clientProject.ToString();
                     Information($"\nclientProjectPath={clientProjectPath}");
                     Information($"packageId={packageId}");
 


### PR DESCRIPTION
Use the logic from the net5 cake recipe.  In order for a Nuget
package artifact (.nupkg) to be created, the csproj file must
now have a PackageId property that is populated.

Note that PackageId value also determines what the filename
will be for the .nupkg/.snupkg artifacts.

Also stop output of project paths unless they have PackageId set.