### PR TITLE
Run tests using DotNetCoreTest(solution)

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -328,11 +328,8 @@ Task("Run-Tests")
             DockerPs(new DockerContainerPsSettings());
         }
 
-        var projectFiles = GetFiles("./tests/**/*.csproj");
-        foreach (var file in projectFiles)
-        {
-            DotNetCoreTest(file.FullPath);
-        }
+        // use 'solution' variable (no need to scan for projects)
+        DotNetCoreTest(solution);
     });
 
 Task("Package")


### PR DESCRIPTION
No need to scan for individual .csproj files, when all of them will
have been registered in the solution (.sln) file anyway to allow
running of tests inside an IDE like Visual Studio / Rider.