### PR TITLE
Put short git SHA hash into SetInformationalVersion

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -1,9 +1,10 @@
-#addin nuget:?package=Cake.FileHelpers&version=3.2.1
-#addin nuget:?package=Cake.Npm&version=0.16.0
-#addin nuget:?package=Cake.Docker&version=0.11.1
+#addin nuget:?package=Cake.Docker&version=1.0.0
+#addin nuget:?package=Cake.FileHelpers&version=4.0.1
+#addin nuget:?package=Cake.Git&version=1.1.0
+#addin nuget:?package=Cake.Npm&version=1.0.0
 #tool nuget:?package=xunit.runner.console&version=2.4.1
 
-Information("build-net5.cake -- Dec-29-2021");
+Information("build-net5.cake -- Feb-11-2022");
 var target = Argument("target", "Default");
 
 // RELEASE STRATEGY: old vs new git flow (master branch vs trunk-based release strategy)
@@ -32,6 +33,15 @@ else if ((useMasterReleaseStrategy && AppVeyor.Environment.Repository.Branch != 
     packageVersion += "-alpha";
 }
 Information($"packageVersion={packageVersion}");
+
+// Get the current git hash
+// https://philipm.at/2018/versioning_assemblies_with_cake.html
+var gitRepo = MakeAbsolute(Directory("./"));
+var gitBranch = GitBranchCurrent(gitRepo);
+var gitShortHash = gitBranch.Tip.Sha.Substring(0, 8);
+Information($"gitShortHash={gitShortHash}");
+var informationalVersion=$"{packageVersion}+{gitShortHash}";
+Information($"informationalVersion={informationalVersion}");
 
 var configuration = "Release";
 Information($"configuration={configuration}");
@@ -313,6 +323,7 @@ Task("Build")
                 Verbosity = DotNetCoreVerbosity.Minimal
             }
             .SetVersion(packageVersion)
+            .SetInformationalVersion($"{packageVersion}+{gitShortHash}")
 
             // msbuild.log specified explicitly, see https://github.com/cake-build/cake/issues/1764
             .AddFileLogger(new MSBuildFileLoggerSettings { LogFile = "msbuild.log" })
@@ -350,7 +361,9 @@ Task("Package")
             {
                 Configuration = configuration,
                 OutputDirectory = hostArtifactsDir,
-                MSBuildSettings = new DotNetCoreMSBuildSettings().SetVersion(packageVersion)
+                MSBuildSettings = new DotNetCoreMSBuildSettings()
+                    .SetVersion(packageVersion)
+                    .SetInformationalVersion($"{packageVersion}+{gitShortHash}")
             });
 
             // add a githash.txt file to the host output directory (must be after DotNetCorePublish)
@@ -393,7 +406,9 @@ Task("Package")
                 DotNetCorePack(clientProjectPath, new DotNetCorePackSettings
                 {
                     Configuration = configuration,
-                    MSBuildSettings = new DotNetCoreMSBuildSettings().SetVersion(packageVersion),
+                    MSBuildSettings = new DotNetCoreMSBuildSettings()
+                        .SetVersion(packageVersion)
+                        .SetInformationalVersion($"{packageVersion}+{gitShortHash}"),
                     NoBuild = true,
                     OutputDirectory = artifactsDir,
                     IncludeSymbols = true,

--- a/build-net5.cake
+++ b/build-net5.cake
@@ -323,7 +323,7 @@ Task("Build")
                 Verbosity = DotNetCoreVerbosity.Minimal
             }
             .SetVersion(packageVersion)
-            .SetInformationalVersion($"{packageVersion}+{gitShortHash}")
+            .SetInformationalVersion(informationalVersion)
 
             // msbuild.log specified explicitly, see https://github.com/cake-build/cake/issues/1764
             .AddFileLogger(new MSBuildFileLoggerSettings { LogFile = "msbuild.log" })
@@ -363,7 +363,7 @@ Task("Package")
                 OutputDirectory = hostArtifactsDir,
                 MSBuildSettings = new DotNetCoreMSBuildSettings()
                     .SetVersion(packageVersion)
-                    .SetInformationalVersion($"{packageVersion}+{gitShortHash}")
+                    .SetInformationalVersion(informationalVersion)
             });
 
             // add a githash.txt file to the host output directory (must be after DotNetCorePublish)
@@ -408,7 +408,7 @@ Task("Package")
                     Configuration = configuration,
                     MSBuildSettings = new DotNetCoreMSBuildSettings()
                         .SetVersion(packageVersion)
-                        .SetInformationalVersion($"{packageVersion}+{gitShortHash}"),
+                        .SetInformationalVersion(informationalVersion),
                     NoBuild = true,
                     OutputDirectory = artifactsDir,
                     IncludeSymbols = true,

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-This file supports build.ps1.
+1.0


### PR DESCRIPTION
Append the current git hash to the assembly's information version string.
When using dotPeek, it will display as "Product Version" such as
"8.4.0-dev+58587860".

Refs:

- https://philipm.at/2018/versioning_assemblies_with_cake.html
- https://stackoverflow.com/a/69721691
- https://cakebuild.net/api/Cake.Common.Tools.DotNet.MSBuild/DotNetMSBuildSettingsExtensions/
- https://stackoverflow.com/a/45248069
- https://www.hanselman.com/blog/adding-a-git-commit-hash-and-azure-devops-build-number-and-build-id-to-an-aspnet-website