### PR TITLE
Remove alpha package suffix

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -27,11 +27,6 @@ if (!AppVeyor.IsRunningOnAppVeyor)
 {
     packageVersion += "-dev";
 }
-else if ((useMasterReleaseStrategy && AppVeyor.Environment.Repository.Branch != "master")
-    || (!useMasterReleaseStrategy && !AppVeyor.Environment.Repository.Branch.StartsWith("release/")))
-{
-    packageVersion += "-alpha";
-}
 Information($"packageVersion={packageVersion}");
 
 // Get the current git hash


### PR DESCRIPTION
We were getting `NuGet Warning NU5104` on our release builds.
- See: https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104

Since we no longer need to differentiate between prerelease and production builds for `build-net5`, this update removes the `-alpha` suffix on these builds.