### PR TITLE
Remove alpha pkg suffix from Framework builds

### DIFF
--- a/build-net5.cake
+++ b/build-net5.cake
@@ -4,7 +4,7 @@
 #addin nuget:?package=Cake.Npm&version=1.0.0
 #tool nuget:?package=xunit.runner.console&version=2.4.1
 
-Information("build-net5.cake -- Feb-11-2022");
+Information("build-net5.cake -- Aug-22-2022");
 var target = Argument("target", "Default");
 
 // RELEASE STRATEGY: old vs new git flow (master branch vs trunk-based release strategy)

--- a/build-webapi-netfx.cake
+++ b/build-webapi-netfx.cake
@@ -2,7 +2,7 @@
 #tool nuget:?package=xunit.runner.console&version=2.4.1
 
 var target = Argument("target", "Default");
-Information("build-webapi-netfx.cake -- Dec-8-2021");
+Information("build-webapi-netfx.cake -- Aug-30-2022");
 
 var versionFromFile = FileReadText("./version.txt")
                     .Trim()
@@ -22,11 +22,6 @@ var packageVersion = version;
 if (!AppVeyor.IsRunningOnAppVeyor)
 {
     packageVersion += "-dev";
-}
-else if ((!isNewEnvironment && AppVeyor.Environment.Repository.Branch != "master")
-          || (isNewEnvironment && !AppVeyor.Environment.Repository.Branch.StartsWith("release/")))
-{
-    packageVersion += "-alpha";
 }
 
 var configuration = "Release";


### PR DESCRIPTION
follow up for #53 

Also updates the version information at the top of the file for both.